### PR TITLE
Add tvOS platform support

### DIFF
--- a/Sources/GlyphixTextFx/GlyphixText/GlyphixText.swift
+++ b/Sources/GlyphixTextFx/GlyphixText/GlyphixText.swift
@@ -35,7 +35,7 @@ public struct GlyphixText {
     }
 
     /// Creates a text view that displays a localized string resource.
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
     public init(_ resource: LocalizedStringResource, countsDown: Bool = false) {
         self.init(text: .init(localized: resource), countsDown: true)
     }
@@ -91,7 +91,7 @@ public struct GlyphixText {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
     private func sizeThatFits(_ proposal: ProposedViewSize, view: GlyphixTextLabel) -> CGSize {
         switch proposal {
         case .zero:
@@ -117,7 +117,7 @@ public struct GlyphixText {
     }
 }
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 
 extension GlyphixText: UIViewRepresentable {
@@ -130,7 +130,7 @@ extension GlyphixText: UIViewRepresentable {
         updateView(uiView)
     }
 
-    @available(iOS 16.0, *)
+    @available(iOS 16.0, tvOS 16.0, *)
     public func sizeThatFits(_ proposal: ProposedViewSize, uiView: GlyphixTextLabel, context: Context) -> CGSize? {
         sizeThatFits(proposal, view: uiView)
     }

--- a/Sources/GlyphixTextFx/GlyphixTextLabel.swift
+++ b/Sources/GlyphixTextFx/GlyphixTextLabel.swift
@@ -109,7 +109,7 @@ open class GlyphixTextLabel: PlatformView {
     public var preferredMaxLayoutWidth: CGFloat = 0 {
         didSet {
             _invalidateIntrinsicContentSize()
-            #if os(iOS)
+            #if os(iOS) || os(tvOS)
             let needsDoubleUpdateConstraintsPass = self.gtf_invokeSuper(forSelectorReturnsBoolean: "_needsDoubleUpdateConstraintsPass")
             self.gtf_invokeSuper(
                 for: "_needsDoubleUpdateConstraintsPassMayHaveChangedFrom:",
@@ -136,7 +136,7 @@ open class GlyphixTextLabel: PlatformView {
     override public init(frame: CGRect) {
         super.init(frame: frame)
 
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         configureAutoLayoutMethods()
         self.layer.addSublayer(textLayer)
         #elseif os(macOS)
@@ -148,7 +148,7 @@ open class GlyphixTextLabel: PlatformView {
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
 
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         configureAutoLayoutMethods()
         self.layer.addSublayer(textLayer)
         #elseif os(macOS)
@@ -175,7 +175,7 @@ open class GlyphixTextLabel: PlatformView {
         invalidateIntrinsicContentSize()
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(tvOS)
     override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         textLayer.effectiveAppearanceDidChange(traitCollection)
     }

--- a/Sources/GlyphixTextFx/GlyphixTextLayer.swift
+++ b/Sources/GlyphixTextFx/GlyphixTextLayer.swift
@@ -7,7 +7,7 @@ import Choreographer
 @_exported import GlyphixTypesetter
 import Respring
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit

--- a/Sources/GlyphixTextFx/Platform.swift
+++ b/Sources/GlyphixTextFx/Platform.swift
@@ -3,7 +3,7 @@
 //  Copyright (c) 2024 ktiays. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 @_exported import UIKit
 
 public typealias PlatformColor = UIColor
@@ -125,7 +125,7 @@ func ceil(_ size: CGSize) -> CGSize {
 
 @inlinable
 func PlatformInsetsEqual(_ aInsets: PlatformInsets, _ bInsets: PlatformInsets) -> Bool {
-    #if os(iOS)
+    #if os(iOS) || os(tvOS)
     return aInsets == bInsets
     #elseif os(macOS)
     return NSEdgeInsetsEqual(aInsets, bInsets)

--- a/Sources/GlyphixTypesetter/Platform.swift
+++ b/Sources/GlyphixTypesetter/Platform.swift
@@ -3,7 +3,7 @@
 //  Copyright (c) 2025 ktiays. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 
 public typealias PlatformFont = UIFont
@@ -16,7 +16,11 @@ public typealias PlatformFont = NSFont
 extension PlatformFont {
 
     public static var glyphixDefaultFont: PlatformFont {
+        #if os(tvOS)
+        .systemFont(ofSize: 20)
+        #else
         .systemFont(ofSize: PlatformFont.labelFontSize)
+        #endif
     }
 }
 

--- a/Sources/GlyphixTypesetter/TextLayout.swift
+++ b/Sources/GlyphixTypesetter/TextLayout.swift
@@ -6,7 +6,7 @@
 import CoreText
 import With
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit


### PR DESCRIPTION
GlyphixTextFx's UIKit code paths compile cleanly on tvOS with minimal changes.
This PR adds tvOS support across the package:

**GlyphixTextFx module:**
- `Platform.swift`: `#if os(iOS)` → `#if os(iOS) || os(tvOS)` for UIKit type aliases and color resolution
- `GlyphixTextLabel.swift`: same guard update for UIKit view lifecycle
- `GlyphixTextLayer.swift`: same guard update for UIKit imports
- `GlyphixText.swift`: add `tvOS 16.0` to `@available` annotations for `LocalizedStringResource`, `ProposedViewSize`, and `sizeThatFits`

**GlyphixTypesetter module:**
- `Platform.swift`: add tvOS guard; use hardcoded default font size (20pt) on tvOS where `UIFont.labelFontSize` is unavailable
- `TextLayout.swift`: add tvOS to UIKit import guard

`UIAnimationDragCoefficient` references remain iOS-only as that symbol does not exist on tvOS.